### PR TITLE
Fix bad selector error message formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,11 +112,9 @@ if (global.document) {
 
   exports.validateSelector = function(selector) {
     if (!exports.isSelectorValid(selector)) {
-      throw {
-        name: "BadSelectorError",
-        code: "EBADSELECTOR",
-        message: selector + " is not a valid selector"
-      }
+      var error = new SyntaxError(selector + ' is not a valid selector')
+      error.code = 'EBADSELECTOR';
+      throw error;
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ if (global.document) {
 
   exports.validateSelector = function(selector) {
     if (!exports.isSelectorValid(selector)) {
-      var error = new SyntaxError(selector + ' is not a valid selector')
+      var error = new SyntaxError(selector + ' is not a valid selector');
       error.code = 'EBADSELECTOR';
       throw error;
     }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var util = require("util");
+
 /**
  * Originally ported from https://github.com/keeganstreet/specificity/blob/866bf7ab4e7f62a7179c15b13a95af4e1c7b1afa/specificity.js
  *
@@ -112,9 +114,11 @@ if (global.document) {
 
   exports.validateSelector = function(selector) {
     if (!exports.isSelectorValid(selector)) {
-      var  error = new Error("'#{selector}' is not a valid selector")
-      error.code = 'EBADSELECTOR'
-      throw error;
+      throw {
+        name: "BadSelectorError",
+        code: "EBADSELECTOR",
+        message: util.format("'%s' is not a valid selector", selector)
+      }
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var util = require("util");
-
 /**
  * Originally ported from https://github.com/keeganstreet/specificity/blob/866bf7ab4e7f62a7179c15b13a95af4e1c7b1afa/specificity.js
  *
@@ -117,7 +115,7 @@ if (global.document) {
       throw {
         name: "BadSelectorError",
         code: "EBADSELECTOR",
-        message: util.format("'%s' is not a valid selector", selector)
+        message: selector + " is not a valid selector"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clear-cut",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Calculate specificity of CSS selectors",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clear-cut",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Calculate specificity of CSS selectors",
   "main": "./index.js",
   "scripts": {

--- a/spec/specificity-spec.coffee
+++ b/spec/specificity-spec.coffee
@@ -74,4 +74,11 @@ describe "clear-cut", ->
   describe "validateSelector(selector)", ->
     it "throws an error if the selector is invalid", ->
       expect(validateSelector('body')).toBeUndefined()
-      expect(-> validateSelector('<>')).toThrow()
+      badSelector = "<>"
+      errorMessage = null
+      try
+        validateSelector(badSelector)
+      catch error
+        errorMessage = error.message
+
+      expect(errorMessage).toContain(badSelector)

--- a/spec/specificity-spec.coffee
+++ b/spec/specificity-spec.coffee
@@ -75,10 +75,12 @@ describe "clear-cut", ->
     it "throws an error if the selector is invalid", ->
       expect(validateSelector('body')).toBeUndefined()
       badSelector = "<>"
-      errorMessage = null
+      validateError = null
       try
         validateSelector(badSelector)
       catch error
-        errorMessage = error.message
+        validateError = error
 
-      expect(errorMessage).toContain(badSelector)
+      expect(validateError.message).toContain(badSelector)
+      expect(validateError.code).toBe 'EBADSELECTOR'
+      expect(validateError.name).toBe 'SyntaxError'


### PR DESCRIPTION
This should fix the build errors we're encountering in https://github.com/atom/atom/pull/6368

Basically we were formatting the error message a-la-Coffeescript, but the file is actually written in Javascript. Please note that I used [the style suggested by Douglas Crockford for throwing exceptions](http://stackoverflow.com/a/1137209/464250), which I find to be more readable in this particular case.